### PR TITLE
fix inflating crash when used outside Activity (issue #16 and #9)

### DIFF
--- a/pinlockview/src/main/res/layout-v21/layout_number_item.xml
+++ b/pinlockview/src/main/res/layout-v21/layout_number_item.xml
@@ -10,6 +10,6 @@
         android:id="@+id/button"
         android:layout_width="64dp"
         android:layout_height="64dp"
-        android:background="?android:attr/selectableItemBackground"/>
+        android:background="?android:attr/selectableItemBackgroundBorderless"/>
 
 </LinearLayout>


### PR DESCRIPTION
Hello. I'm using your library and I like it. But I found a bug when PinLockView used outside Activity same as in issue #16 and #9. My little commit will fix this bug. Please accept my pull request and add this fix to new version. Thanks for your beautiful library.