### PR TITLE
LTR direction for indicator view and PinLockView

### DIFF
--- a/pinlockview/src/main/java/com/andrognito/pinlockview/IndicatorDots.java
+++ b/pinlockview/src/main/java/com/andrognito/pinlockview/IndicatorDots.java
@@ -4,6 +4,7 @@ import android.animation.LayoutTransition;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.support.annotation.IntDef;
+import android.support.v4.view.ViewCompat;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
@@ -70,6 +71,7 @@ public class IndicatorDots extends LinearLayout {
     }
 
     private void initView(Context context) {
+        ViewCompat.setLayoutDirection(this, ViewCompat.LAYOUT_DIRECTION_LTR);
         if (mIndicatorType == 0) {
             for (int i = 0; i < mPinLength; i++) {
                 View dot = new View(context);

--- a/pinlockview/src/main/java/com/andrognito/pinlockview/LTRGridLayoutManager.java
+++ b/pinlockview/src/main/java/com/andrognito/pinlockview/LTRGridLayoutManager.java
@@ -1,0 +1,31 @@
+package com.andrognito.pinlockview;
+
+import android.content.Context;
+import android.support.v7.widget.GridLayoutManager;
+import android.util.AttributeSet;
+
+/**
+ * Used to always maintain an LTR layout no matter what is the real device's layout direction
+ * to avoid an unwanted reversed direction in RTL devices
+ * Created by Idan on 7/6/2017.
+ */
+
+public class LTRGridLayoutManager extends GridLayoutManager {
+
+    public LTRGridLayoutManager(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    public LTRGridLayoutManager(Context context, int spanCount) {
+        super(context, spanCount);
+    }
+
+    public LTRGridLayoutManager(Context context, int spanCount, int orientation, boolean reverseLayout) {
+        super(context, spanCount, orientation, reverseLayout);
+    }
+
+    @Override
+    protected boolean isLayoutRTL(){
+        return false;
+    }
+}

--- a/pinlockview/src/main/java/com/andrognito/pinlockview/PinLockView.java
+++ b/pinlockview/src/main/java/com/andrognito/pinlockview/PinLockView.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.Nullable;
-import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 
@@ -170,7 +169,7 @@ public class PinLockView extends RecyclerView {
     }
 
     private void initView() {
-        setLayoutManager(new GridLayoutManager(getContext(), 3));
+        setLayoutManager(new LTRGridLayoutManager(getContext(), 3));
 
         mAdapter = new PinLockAdapter(getContext());
         mAdapter.setOnItemClickListener(mOnNumberClickListener);


### PR DESCRIPTION
Hello,
I've just made a couple of changes after I noticed that in my device the `PinLockView` and `IndicatorDots` views are shown in RTL because of my native device's language is Hebrew (which is an RTL language), and so the sample app looked like this:  (Don't be worry about the big numeric text sizes and everything in the screenshots, I just changed it in my sample app's view attributes)
![temp_screenshot2](https://user-images.githubusercontent.com/5266462/27965801-97074e5e-6345-11e7-8f84-d038a7718d88.png)

And after my submitted changes:
![temp_screenshot1](https://user-images.githubusercontent.com/5266462/27965751-75ac8b2a-6345-11e7-8304-b8b7b0e4f60f.png)

Of course I also checked the results with an LTR based language (English) and it looked the same as in RTL based language (Hebrew).

Thank you for a great library!
