### PR TITLE
change compile into implementation keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This library is available in **jCenter** which is the default Maven repository u
 dependencies {
     // other dependencies here
     
-    compile 'com.andrognito.pinlockview:pinlockview:2.1.0'
+    implementation 'com.andrognito.pinlockview:pinlockview:2.1.0'
 }
 ```
 


### PR DESCRIPTION
as Android Studio 3.0 hits the stable version, it's a good move to switch to new gradle commands