### PR TITLE
Added enter button and attribute to swap enter and delete buttons

### DIFF
--- a/app/src/main/res/layout/activity_sample.xml
+++ b/app/src/main/res/layout/activity_sample.xml
@@ -47,6 +47,8 @@
         app:keypadButtonSize="72dp"
         app:keypadShowDeleteButton="true"
         app:keypadTextColor="@color/white"
-        app:keypadTextSize="18dp" />
+        app:keypadTextSize="18dp"
+        app:keypadShowEnterButton="true"
+        app:keypadSwapEnterDeleteButtons="true"/>
 
 </RelativeLayout>

--- a/pinlockview/src/main/java/com/andrognito/pinlockview/CustomizationOptionsBundle.java
+++ b/pinlockview/src/main/java/com/andrognito/pinlockview/CustomizationOptionsBundle.java
@@ -5,7 +5,7 @@ import android.graphics.drawable.Drawable;
 /**
  * The customization options for the buttons in {@link PinLockView}
  * passed to the {@link PinLockAdapter} to decorate the individual views
- *
+ * <p>
  * Created by aritraroy on 01/06/16.
  */
 public class CustomizationOptionsBundle {
@@ -18,6 +18,10 @@ public class CustomizationOptionsBundle {
     private int deleteButtonSize;
     private boolean showDeleteButton;
     private int deleteButtonPressesColor;
+
+    private boolean showEnterButton;
+    private int pinLength;
+    private boolean swapEnterDeleteButtons;
 
     public CustomizationOptionsBundle() {
     }
@@ -84,5 +88,29 @@ public class CustomizationOptionsBundle {
 
     public void setDeleteButtonPressesColor(int deleteButtonPressesColor) {
         this.deleteButtonPressesColor = deleteButtonPressesColor;
+    }
+
+    public boolean isShowEnterButton() {
+        return showEnterButton;
+    }
+
+    public void setShowEnterButton(boolean showEnterButton) {
+        this.showEnterButton = showEnterButton;
+    }
+
+    public int getPinLength() {
+        return pinLength;
+    }
+
+    public void setPinLength(int pinLength) {
+        this.pinLength = pinLength;
+    }
+
+    public boolean isSwapEnterDeleteButtons() {
+        return swapEnterDeleteButtons;
+    }
+
+    public void setSwapEnterDeleteButtons(boolean swapEnterDeleteButtons) {
+        this.swapEnterDeleteButtons = swapEnterDeleteButtons;
     }
 }

--- a/pinlockview/src/main/java/com/andrognito/pinlockview/PinLockAdapter.java
+++ b/pinlockview/src/main/java/com/andrognito/pinlockview/PinLockAdapter.java
@@ -21,11 +21,18 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 
     private static final int VIEW_TYPE_NUMBER = 0;
     private static final int VIEW_TYPE_DELETE = 1;
+    private static final int VIEW_TYPE_ENTER = 2;
 
     private Context mContext;
     private CustomizationOptionsBundle mCustomizationOptionsBundle;
     private OnNumberClickListener mOnNumberClickListener;
     private OnDeleteClickListener mOnDeleteClickListener;
+
+    private OnEnterClickListener mOnEnterClickListener;
+
+    private int enterButtonPosition = 9;
+    private int deleteButtonPosition = 11;
+
     private int mPinLength;
 
     private int[] mKeyValues;
@@ -43,9 +50,12 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         if (viewType == VIEW_TYPE_NUMBER) {
             View view = inflater.inflate(R.layout.layout_number_item, parent, false);
             viewHolder = new NumberViewHolder(view);
-        } else {
+        } else if (viewType == VIEW_TYPE_DELETE) {
             View view = inflater.inflate(R.layout.layout_delete_item, parent, false);
             viewHolder = new DeleteViewHolder(view);
+        } else {
+            View view = inflater.inflate(R.layout.layout_enter_item, parent, false);
+            viewHolder = new EnterViewHolder(view);
         }
         return viewHolder;
     }
@@ -58,6 +68,9 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         } else if (holder.getItemViewType() == VIEW_TYPE_DELETE) {
             DeleteViewHolder vh2 = (DeleteViewHolder) holder;
             configureDeleteButtonHolder(vh2);
+        } else if (holder.getItemViewType() == VIEW_TYPE_ENTER) {
+            EnterViewHolder vh3 = (EnterViewHolder) holder;
+            configureEnterButtonHolder(vh3);
         }
     }
 
@@ -111,6 +124,35 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         }
     }
 
+    private void configureEnterButtonHolder(EnterViewHolder holder) {
+        if (holder != null) {
+            if (mCustomizationOptionsBundle.isShowEnterButton() && mPinLength >= mCustomizationOptionsBundle.getPinLength()) {
+                holder.mEnterButton.setVisibility(View.VISIBLE);
+
+                if (mCustomizationOptionsBundle != null) {
+                    holder.mEnterButton.setTextColor(mCustomizationOptionsBundle.getTextColor());
+                    if (mCustomizationOptionsBundle.getButtonBackgroundDrawable() != null) {
+                        if (Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.JELLY_BEAN) {
+                            holder.mEnterButton.setBackgroundDrawable(
+                                    mCustomizationOptionsBundle.getButtonBackgroundDrawable());
+                        } else {
+                            holder.mEnterButton.setBackground(
+                                    mCustomizationOptionsBundle.getButtonBackgroundDrawable());
+                        }
+                    }
+                    holder.mEnterButton.setTextSize(TypedValue.COMPLEX_UNIT_PX,
+                            mCustomizationOptionsBundle.getTextSize());
+                    LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                            mCustomizationOptionsBundle.getButtonSize(),
+                            mCustomizationOptionsBundle.getButtonSize());
+                    holder.mEnterButton.setLayoutParams(params);
+                }
+            } else {
+                holder.mEnterButton.setVisibility(View.GONE);
+            }
+        }
+    }
+
     @Override
     public int getItemCount() {
         return 12;
@@ -118,7 +160,10 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 
     @Override
     public int getItemViewType(int position) {
-        if (position == getItemCount() - 1) {
+        if (position == getEnterButtonPosition()) {
+            return VIEW_TYPE_ENTER;
+        }
+        if (position == getDeleteButtonPosition()) {
             return VIEW_TYPE_DELETE;
         }
         return VIEW_TYPE_NUMBER;
@@ -170,12 +215,34 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         this.mOnDeleteClickListener = onDeleteClickListener;
     }
 
+    public void setOnEnterClickListener(OnEnterClickListener onEnterClickListener) {
+        this.mOnEnterClickListener = onEnterClickListener;
+    }
+
     public CustomizationOptionsBundle getCustomizationOptions() {
         return mCustomizationOptionsBundle;
     }
 
     public void setCustomizationOptions(CustomizationOptionsBundle customizationOptionsBundle) {
         this.mCustomizationOptionsBundle = customizationOptionsBundle;
+        setEnterButtonPosition(mCustomizationOptionsBundle.isSwapEnterDeleteButtons() ? 11 : 9);
+        setDeleteButtonPosition(mCustomizationOptionsBundle.isSwapEnterDeleteButtons() ? 9 : 11);
+    }
+
+    public int getEnterButtonPosition() {
+        return enterButtonPosition;
+    }
+
+    public void setEnterButtonPosition(int enterButtonPosition) {
+        this.enterButtonPosition = enterButtonPosition;
+    }
+
+    public int getDeleteButtonPosition() {
+        return deleteButtonPosition;
+    }
+
+    public void setDeleteButtonPosition(int deleteButtonPosition) {
+        this.deleteButtonPosition = deleteButtonPosition;
     }
 
     public class NumberViewHolder extends RecyclerView.ViewHolder {
@@ -250,6 +317,23 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         }
     }
 
+    public class EnterViewHolder extends RecyclerView.ViewHolder {
+        Button mEnterButton;
+
+        public EnterViewHolder(final View itemView) {
+            super(itemView);
+            mEnterButton = (Button) itemView.findViewById(R.id.button);
+            mEnterButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (mOnEnterClickListener != null) {
+                        mOnEnterClickListener.onEnterClicked();
+                    }
+                }
+            });
+        }
+    }
+
     public interface OnNumberClickListener {
         void onNumberClicked(int keyValue);
     }
@@ -258,5 +342,9 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         void onDeleteClicked();
 
         void onDeleteLongClicked();
+    }
+
+    public interface OnEnterClickListener {
+        void onEnterClicked();
     }
 }

--- a/pinlockview/src/main/java/com/andrognito/pinlockview/PinLockView.java
+++ b/pinlockview/src/main/java/com/andrognito/pinlockview/PinLockView.java
@@ -29,6 +29,9 @@ public class PinLockView extends RecyclerView {
     private Drawable mDeleteButtonDrawable;
     private boolean mShowDeleteButton;
 
+    private boolean mShowEnterButton;
+    private boolean mSwapEnterDeleteButtons;
+
     private IndicatorDots mIndicatorDots;
     private PinLockAdapter mAdapter;
     private PinLockListener mPinLockListener;
@@ -39,7 +42,7 @@ public class PinLockView extends RecyclerView {
             = new PinLockAdapter.OnNumberClickListener() {
         @Override
         public void onNumberClicked(int keyValue) {
-            if (mPin.length() < getPinLength()) {
+            if (mPin.length() < getPinLength() || mShowEnterButton) {
                 mPin = mPin.concat(String.valueOf(keyValue));
 
                 if (isIndicatorDotsAttached()) {
@@ -48,11 +51,16 @@ public class PinLockView extends RecyclerView {
 
                 if (mPin.length() == 1) {
                     mAdapter.setPinLength(mPin.length());
-                    mAdapter.notifyItemChanged(mAdapter.getItemCount() - 1);
+                    mAdapter.notifyItemChanged(mAdapter.getDeleteButtonPosition());
+                }
+
+                if (mPin.length() == mPinLength) {
+                    mAdapter.setPinLength(mPin.length());
+                    mAdapter.notifyItemChanged(mAdapter.getEnterButtonPosition());
                 }
 
                 if (mPinLockListener != null) {
-                    if (mPin.length() == mPinLength) {
+                    if (mPin.length() == mPinLength && !mShowEnterButton) {
                         mPinLockListener.onComplete(mPin);
                     } else {
                         mPinLockListener.onPinChange(mPin.length(), mPin);
@@ -73,7 +81,9 @@ public class PinLockView extends RecyclerView {
 
                 } else {
                     if (mPinLockListener != null) {
-                        mPinLockListener.onComplete(mPin);
+                        if (!mShowEnterButton) {
+                            mPinLockListener.onComplete(mPin);
+                        }
                     }
                 }
             }
@@ -93,7 +103,12 @@ public class PinLockView extends RecyclerView {
 
                 if (mPin.length() == 0) {
                     mAdapter.setPinLength(mPin.length());
-                    mAdapter.notifyItemChanged(mAdapter.getItemCount() - 1);
+                    mAdapter.notifyItemChanged(mAdapter.getDeleteButtonPosition());
+                }
+
+                if (mPin.length() == mPinLength - 1) {
+                    mAdapter.setPinLength(mPin.length());
+                    mAdapter.notifyItemChanged(mAdapter.getEnterButtonPosition());
                 }
 
                 if (mPinLockListener != null) {
@@ -116,6 +131,16 @@ public class PinLockView extends RecyclerView {
             resetPinLockView();
             if (mPinLockListener != null) {
                 mPinLockListener.onEmpty();
+            }
+        }
+    };
+
+    private PinLockAdapter.OnEnterClickListener mOnEnterClickListener
+            = new PinLockAdapter.OnEnterClickListener() {
+        @Override
+        public void onEnterClicked() {
+            if (mPin.length() >= mPinLength) {
+                mPinLockListener.onComplete(mPin);
             }
         }
     };
@@ -151,6 +176,12 @@ public class PinLockView extends RecyclerView {
             mDeleteButtonDrawable = typedArray.getDrawable(R.styleable.PinLockView_keypadDeleteButtonDrawable);
             mShowDeleteButton = typedArray.getBoolean(R.styleable.PinLockView_keypadShowDeleteButton, true);
             mDeleteButtonPressedColor = typedArray.getColor(R.styleable.PinLockView_keypadDeleteButtonPressedColor, ResourceUtils.getColor(getContext(), R.color.greyish));
+
+            mShowEnterButton = typedArray.getBoolean(R.styleable.PinLockView_keypadShowEnterButton, false);
+            if (mShowEnterButton) {
+                mShowDeleteButton = true;
+            }
+            mSwapEnterDeleteButtons = typedArray.getBoolean(R.styleable.PinLockView_keypadSwapEnterDeleteButtons, false);
         } finally {
             typedArray.recycle();
         }
@@ -165,6 +196,9 @@ public class PinLockView extends RecyclerView {
         mCustomizationOptionsBundle.setShowDeleteButton(mShowDeleteButton);
         mCustomizationOptionsBundle.setDeleteButtonPressesColor(mDeleteButtonPressedColor);
 
+        mCustomizationOptionsBundle.setShowEnterButton(mShowEnterButton);
+        mCustomizationOptionsBundle.setPinLength(mPinLength);
+        mCustomizationOptionsBundle.setSwapEnterDeleteButtons(mSwapEnterDeleteButtons);
         initView();
     }
 
@@ -174,6 +208,9 @@ public class PinLockView extends RecyclerView {
         mAdapter = new PinLockAdapter(getContext());
         mAdapter.setOnItemClickListener(mOnNumberClickListener);
         mAdapter.setOnDeleteClickListener(mOnDeleteClickListener);
+
+        mAdapter.setOnEnterClickListener(mOnEnterClickListener);
+
         mAdapter.setCustomizationOptions(mCustomizationOptionsBundle);
         setAdapter(mAdapter);
 
@@ -405,7 +442,8 @@ public class PinLockView extends RecyclerView {
         clearInternalPin();
 
         mAdapter.setPinLength(mPin.length());
-        mAdapter.notifyItemChanged(mAdapter.getItemCount() - 1);
+        mAdapter.notifyItemChanged(mAdapter.getEnterButtonPosition());
+        mAdapter.notifyItemChanged(mAdapter.getDeleteButtonPosition());
 
         if (mIndicatorDots != null) {
             mIndicatorDots.updateDot(mPin.length());

--- a/pinlockview/src/main/res/layout/layout_enter_item.xml
+++ b/pinlockview/src/main/res/layout/layout_enter_item.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:clipChildren="false"
+    android:clipToPadding="false"
+    android:orientation="vertical">
+
+    <Button
+        android:id="@+id/button"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        android:background="@android:color/transparent"
+        android:text="OK" />
+
+</LinearLayout>

--- a/pinlockview/src/main/res/values/attrs.xml
+++ b/pinlockview/src/main/res/values/attrs.xml
@@ -13,6 +13,9 @@
         <attr name="keypadShowDeleteButton" format="boolean" />
         <attr name="keypadDeleteButtonPressedColor" format="color" />
 
+        <attr name="keypadShowEnterButton" format="boolean" />
+        <attr name="keypadSwapEnterDeleteButtons" format="boolean" />
+
         <attr name="dotEmptyBackground" format="reference" />
         <attr name="dotFilledBackground" format="reference" />
         <attr name="dotDiameter" format="dimension" />


### PR DESCRIPTION
Setting keypadShowEnterButton attribute to true, in principle it makes pinLength a minimum pinLength, overrides keypadShowDeleteButton attribute and sets it to true. onComplete() method is called after clicking enterButton. Setting keypadShowEnterButton to false doesnt change anything.

Attribute keypadSwapEnterDeleteButtons swaps delete and enter buttons if set to true.

![image](https://user-images.githubusercontent.com/20399227/33769806-37a8f24c-dc34-11e7-842f-b814221e841e.png)
