### PR TITLE
fix conflict of RecyclerView's and ViewPager's lifecycles

### DIFF
--- a/pinlockview/src/main/java/com/andrognito/pinlockview/PinLockAdapter.java
+++ b/pinlockview/src/main/java/com/andrognito/pinlockview/PinLockAdapter.java
@@ -55,9 +55,68 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         if (holder.getItemViewType() == VIEW_TYPE_NUMBER) {
             NumberViewHolder vh1 = (NumberViewHolder) holder;
             configureNumberButtonHolder(vh1, position);
+            bindNumberViewHolder(vh1);
         } else if (holder.getItemViewType() == VIEW_TYPE_DELETE) {
             DeleteViewHolder vh2 = (DeleteViewHolder) holder;
             configureDeleteButtonHolder(vh2);
+            bindDeleteViewHolder(vh2);
+        }
+    }
+
+    private void bindNumberViewHolder(NumberViewHolder holder){
+        holder.getNumberButton().setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (mOnNumberClickListener != null) {
+                    mOnNumberClickListener.onNumberClicked((Integer) v.getTag());
+                }
+            }
+        });
+    }
+
+    private void bindDeleteViewHolder(final DeleteViewHolder holder) {
+        if (mCustomizationOptionsBundle.isShowDeleteButton() && mPinLength > 0) {
+            holder.getDeleteButton().setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (mOnDeleteClickListener != null) {
+                        mOnDeleteClickListener.onDeleteClicked();
+                    }
+                }
+            });
+
+            holder.getDeleteButton().setOnLongClickListener(new View.OnLongClickListener() {
+                @Override
+                public boolean onLongClick(View v) {
+                    if (mOnDeleteClickListener != null) {
+                        mOnDeleteClickListener.onDeleteLongClicked();
+                    }
+                    return true;
+                }
+            });
+
+            holder.getDeleteButton().setOnTouchListener(new View.OnTouchListener() {
+                private Rect rect;
+
+                @Override
+                public boolean onTouch(View v, MotionEvent event) {
+                    if (event.getAction() == MotionEvent.ACTION_DOWN) {
+                        holder.getButtonImage().setColorFilter(mCustomizationOptionsBundle
+                                .getDeleteButtonPressesColor());
+                        rect = new Rect(v.getLeft(), v.getTop(), v.getRight(), v.getBottom());
+                    }
+                    if (event.getAction() == MotionEvent.ACTION_UP) {
+                        holder.getButtonImage().clearColorFilter();
+                    }
+                    if (event.getAction() == MotionEvent.ACTION_MOVE) {
+                        if (!rect.contains(v.getLeft() + (int) event.getX(),
+                                v.getTop() + (int) event.getY())) {
+                            holder.getButtonImage().clearColorFilter();
+                        }
+                    }
+                    return false;
+                }
+            });
         }
     }
 
@@ -184,14 +243,10 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         public NumberViewHolder(final View itemView) {
             super(itemView);
             mNumberButton = (Button) itemView.findViewById(R.id.button);
-            mNumberButton.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    if (mOnNumberClickListener != null) {
-                        mOnNumberClickListener.onNumberClicked((Integer) v.getTag());
-                    }
-                }
-            });
+        }
+
+        public Button getNumberButton() {
+            return mNumberButton;
         }
     }
 
@@ -203,50 +258,14 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             super(itemView);
             mDeleteButton = (LinearLayout) itemView.findViewById(R.id.button);
             mButtonImage = (ImageView) itemView.findViewById(R.id.buttonImage);
+        }
 
-            if (mCustomizationOptionsBundle.isShowDeleteButton() && mPinLength > 0) {
-                mDeleteButton.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        if (mOnDeleteClickListener != null) {
-                            mOnDeleteClickListener.onDeleteClicked();
-                        }
-                    }
-                });
+        public LinearLayout getDeleteButton() {
+            return mDeleteButton;
+        }
 
-                mDeleteButton.setOnLongClickListener(new View.OnLongClickListener() {
-                    @Override
-                    public boolean onLongClick(View v) {
-                        if (mOnDeleteClickListener != null) {
-                            mOnDeleteClickListener.onDeleteLongClicked();
-                        }
-                        return true;
-                    }
-                });
-
-                mDeleteButton.setOnTouchListener(new View.OnTouchListener() {
-                    private Rect rect;
-
-                    @Override
-                    public boolean onTouch(View v, MotionEvent event) {
-                        if (event.getAction() == MotionEvent.ACTION_DOWN) {
-                            mButtonImage.setColorFilter(mCustomizationOptionsBundle
-                                    .getDeleteButtonPressesColor());
-                            rect = new Rect(v.getLeft(), v.getTop(), v.getRight(), v.getBottom());
-                        }
-                        if (event.getAction() == MotionEvent.ACTION_UP) {
-                            mButtonImage.clearColorFilter();
-                        }
-                        if (event.getAction() == MotionEvent.ACTION_MOVE) {
-                            if (!rect.contains(v.getLeft() + (int) event.getX(),
-                                    v.getTop() + (int) event.getY())) {
-                                mButtonImage.clearColorFilter();
-                            }
-                        }
-                        return false;
-                    }
-                });
-            }
+        public ImageView getButtonImage() {
+            return mButtonImage;
         }
     }
 


### PR DESCRIPTION
Hello. I found one more little bug - I use your view in few places of my application and recently found that delete button don't work (visible bun not delete numbers) when PinLockView placed in fragment what placed in view pager. In this case - method of RecyclerViewAdapter onBindViewHolder called many times and all business logic (like OnClickListeners and others) placed in ViewHolder class stop to work.   Definitely it's not good idea to place any business logic in ViewHolder class, it must be used only to store inflated views and no more.. Due to RecyclerView's lifecycle all business logic must be implemented in onBindViewHolder() for correct work. In my commit I moved all your business logic from constructors of ViewHolders to methods called from onBindViewHolder. Please check my changes and merge it. Thank you for your beautiful library. 